### PR TITLE
Simplified install using brewcask and hiera-managed params

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,5 @@
 /spec/fixtures/.librarian
 /spec/fixtures/.tmp
 /spec/fixtures/Puppetfile.lock
-/spec/fixtures/modules/boxen/
-/spec/fixtures/modules/stdlib/
+/spec/fixtures/modules
 /spec/fixtures/vendor

--- a/lib/puppet/provider/package/apm.rb
+++ b/lib/puppet/provider/package/apm.rb
@@ -78,11 +78,7 @@ Puppet::Type.type(:package).provide(:apm, :parent => Puppet::Provider::Package) 
   end
 
   def self.home
-    if boxen_home = Facter.value(:boxen_home)
-      "#{boxen_home}/homebrew"
-    else
-      "/usr/local/homebrew"
-    end
+    Facter.value(:homebrew_root)
   end
 
   def self.homedir_prefix

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -2,28 +2,35 @@
 #
 # Usage:
 #
-#     include atom
+#   include atom
+#
+# Parameters:
+#
+#   packages
+#     An array of packages to install
+#   themes
+#     An array of themes to install
 class atom (
-  $ensure = 'present'
+  $ensure   = 'present',
+  $packages = [],
+  $themes   = [],
 ) {
-  package { 'Atom':
-    ensure   => $ensure,
-    flavor   => 'zip',
-    provider => 'compressed_app',
-    source   => 'https://atom.io/download/mac'
+
+  require brewcask
+
+  if !defined(Package['atom']) {
+    package { 'atom':
+      ensure          => $ensure,
+      provider        => 'brewcask',
+      install_options => '--appdir=/Applications',
+    }
   }
 
-  file { "${boxen::config::bindir}/apm":
-    ensure  => link,
-    target  => '/Applications/Atom.app/Contents/Resources/app/apm/node_modules/.bin/apm',
-    mode    => '0755',
-    require => Package['Atom']
-  }
+  $_ensure = $ensure ? { present => latest, default => $ensure }
+  ensure_resource('package', concat($packages, $themes), {
+    ensure   => $_ensure,
+    provider => 'apm',
+    require  => Package['atom'],
+  })
 
-  file { "${boxen::config::bindir}/atom":
-    ensure  => link,
-    target  => '/Applications/Atom.app/Contents/Resources/app/atom.sh',
-    mode    => '0755',
-    require => Package['Atom']
-  }
 }

--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -6,11 +6,11 @@
 define atom::package (
   $ensure = 'latest'
 ) {
-  include atom
+  require atom
 
-  package { $name:
+  ensure_resource('package', $name, {
     ensure   => $ensure,
     provider => 'apm',
-    require  => File["${boxen::config::bindir}/apm"]
-  }
+    require  => Package['atom'],
+  })
 }

--- a/manifests/theme.pp
+++ b/manifests/theme.pp
@@ -6,11 +6,11 @@
 define atom::theme (
   $ensure = 'latest'
 ) {
-  include atom
+  require atom
 
-  package { $name:
+  ensure_resource('package', $name, {
     ensure   => $ensure,
     provider => 'apm',
-    require  => File["${boxen::config::bindir}/apm"]
-  }
+    require  => Package['atom'],
+  })
 }

--- a/spec/classes/atom_spec.rb
+++ b/spec/classes/atom_spec.rb
@@ -1,12 +1,26 @@
 require 'spec_helper'
 
 describe 'atom' do
+  let(:facts) { default_test_facts }
+  let(:params) { {
+    :packages => ['package-1', 'package-2'],
+    :themes   => ['theme-1', 'theme-2']
+  } }
+
   it do
-    should contain_package('Atom').with({
-      :ensure   => 'present',
-      :provider => 'compressed_app',
-      :flavor   => 'zip',
-      :source   => 'https://atom.io/download/mac'
+    should include_class('brewcask')
+
+    should contain_package('atom').with({
+      :ensure          => 'present',
+      :provider        => 'brewcask',
+      :install_options => '--appdir=/Applications',
     })
+
+    %w(package-1 package-2 theme-1 theme-2).each do |pkg|
+      should contain_package(pkg).with({
+        :ensure   => 'latest',
+        :provider => 'apm'
+      })
+    end
   end
 end

--- a/spec/defines/atom__package_spec.rb
+++ b/spec/defines/atom__package_spec.rb
@@ -1,6 +1,7 @@
 require 'spec_helper'
 
 describe 'atom::package' do
+  let(:facts) { default_test_facts }
   let(:title)  { 'example' }
 
   it do

--- a/spec/defines/atom__theme_spec.rb
+++ b/spec/defines/atom__theme_spec.rb
@@ -1,6 +1,7 @@
 require 'spec_helper'
 
 describe 'atom::theme' do
+  let(:facts) { default_test_facts }
   let(:title)  { 'example' }
 
   it do

--- a/spec/fixtures/Puppetfile
+++ b/spec/fixtures/Puppetfile
@@ -1,2 +1,5 @@
-mod 'boxen', '3.6.1', :github_tarball => 'boxen/puppet-boxen'
-mod 'stdlib', '4.1.0', :github_tarball => "puppetlabs/puppetlabs-stdlib"
+mod 'boxen',       '3.3.4', :github_tarball => 'boxen/puppet-boxen'
+mod 'brewcask',    '0.0.4', :github_tarball => 'boxen/puppet-brewcask'
+mod 'homebrew',    '1.2.0', :github_tarball => 'boxen/puppet-homebrew'
+mod 'repository',  '2.2.0', :github_tarball => 'boxen/puppet-repository'
+mod 'stdlib',      '4.1.0', :github_tarball => 'puppetlabs/puppetlabs-stdlib'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,3 +6,11 @@ RSpec.configure do |c|
   c.manifest_dir = File.join(fixture_path, "manifests")
   c.module_path  = File.join(fixture_path, "modules")
 end
+
+def default_test_facts
+  {
+    :boxen_home    => "/test/boxen",
+    :boxen_srcdir  => "/test/boxen/src",
+    :boxen_user    => "testuser",
+  }
+end


### PR DESCRIPTION
Now that [boxen/puppet-boxen](https://github.com/boxen/puppet-boxen) has added [boxen/puppet-brewcask](https://github.com/boxen/puppet-brewcask) as a core dependency and recommends using per-user hiera configuration, should we utilise these methods of installing Atom and its packages/themes?

What this PR does:
- Installs Atom through brewcask
- Ability to pass in packages and themes for easy installing through Hiera-managed params

All that's then needed to install Atom and any packages/ themes is this YAML:
```yaml
atom::packages:
  - linter

atom::themes:
  - monokai

boxen::personal::includes:
  - atom
```

Thoughts?