### PR TITLE
Fix for apm/atom install location

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,3 +4,4 @@ gemfile: "this/does/not/exist"
 rvm:
   - "1.8.7"
   - "2.0.0"
+sudo: false

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -22,7 +22,10 @@ class atom (
     package { 'atom':
       ensure          => $ensure,
       provider        => 'brewcask',
-      install_options => '--appdir=/Applications',
+      install_options => [
+        '--appdir=/Applications',
+        "--binarydir=${boxen::config::bindir}"
+      ]
     }
   }
 

--- a/spec/classes/atom_spec.rb
+++ b/spec/classes/atom_spec.rb
@@ -13,7 +13,7 @@ describe 'atom' do
     should contain_package('atom').with({
       :ensure          => 'present',
       :provider        => 'brewcask',
-      :install_options => '--appdir=/Applications',
+      :install_options => ['--appdir=/Applications', '--binarydir=/test/boxen/bin'],
     })
 
     %w(package-1 package-2 theme-1 theme-2).each do |pkg|


### PR DESCRIPTION
brewcask is defaulting to installing `apm` and `atom` within `/usr/local/bin`. In a base install of Yosemite, that directory doesn't exist and you get errors during install. This points things to the boxen bindir.

Fixes #4  
